### PR TITLE
Fix dimensions error.

### DIFF
--- a/scripts/apply_stack_parallel.R
+++ b/scripts/apply_stack_parallel.R
@@ -42,11 +42,13 @@ apply_stack_parallel <- function(x, fun, args.list = list(), nl = nlayers(x), pr
      pb <- raster::pbCreate(bs$n, progress = progress)
      if(bs$n < nodes)
        nodes <- bs$n
-       
+     
      # Creat cluster function 
+     
      cl_fun <- function(k, x, bs, fun, args.list){
        v <- raster::getValues(x, bs$row[k], bs$nrows[k])
-       t(apply(v, 1, fun, args.list))
+       res <- matrix(apply(v, 1, fun, args.list), ncol = args.list$nl, byrow = TRUE)
+       return(res)
      }
 
      # Get all nodes going
@@ -68,9 +70,7 @@ apply_stack_parallel <- function(x, fun, args.list = list(), nl = nlayers(x), pr
      }
 
      # Process raster tiles
-     for (k in 1:nodes) {
-       
-          print(k)
+     for (k in 1:bs$n) {
        
           # receive results from a node
           d <- snow::recvOneData(cl)


### PR DESCRIPTION
Raster treats NxM array as a matrix for M>1 and as a vector otherwise, unless explicitly declared as a matrix.